### PR TITLE
Edit typo error

### DIFF
--- a/sqinner.py
+++ b/sqinner.py
@@ -10,7 +10,7 @@ import _mssql
 
 program_info = {
     'name': 'Sqinner',
-    'descriptio': 'A MSSQL service login bruteforcer and xp_cmdshell wrapper',
+    'description': 'A MSSQL service login bruteforcer and xp_cmdshell wrapper',
     'author': {
         'name': 'Frank Allenby',
         'email': 'frank@allen.by'


### PR DESCRIPTION
There is typo error in "program_info" key "**descriptio**n" causing KeyError